### PR TITLE
feat: config `rainbow-delimiters` to avoid colorizing html or jsx tags

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -60,5 +60,45 @@ return {
     'HiPhish/rainbow-delimiters.nvim',
     dependencies = { 'nvim-treesitter/nvim-treesitter' },
     event = { 'BufReadPost' },
+    config = function()
+      require('rainbow-delimiters.setup').setup({
+        strategy = {
+          [''] = 'rainbow-delimiters.strategy.global',
+          vim = 'rainbow-delimiters.strategy.local',
+        },
+        query = {
+          [''] = 'rainbow-delimiters',
+          lua = 'rainbow-blocks',
+          -- 这几种文件类型只处理括号对着色
+          javascript = 'rainbow-parens',
+          typescript = 'rainbow-parens',
+          tsx = 'raibaow-parens',
+          vue = 'rainbow-parens',
+          html = 'rainbow-parens',
+          css = 'rainbow-parens',
+          scss = 'rainbow-parens',
+        },
+        highlight = {
+          'RainbowDelimiterRed',
+          'RainbowDelimiterYellow',
+          'RainbowDelimiterBlue',
+          'RainbowDelimiterOrange',
+          'RainbowDelimiterGreen',
+          'RainbowDelimiterViolet',
+          'RainbowDelimiterCyan',
+        },
+        blacklist = {
+          'markdown',
+          'markdown_inline',
+          'text',
+          'txt',
+          'help',
+          'gitcommit',
+          'gitrebase',
+          'diff',
+          'python',
+        },
+      })
+    end,
   },
 }


### PR DESCRIPTION
`rainbow-delimiters`对html或vue文件的html tag默认进行了着色，比如`<html></html>` `<template></template>`这种匹配对，这会覆盖colorscheme原本的颜色。这里增加了一些配置使其在一些特定的文件类型中只进行括号对着色`{[()]}`