### PR TITLE
feat(dropbar): use 'l' 'h' keys to open or close context menu

### DIFF
--- a/lua/plugins/editors.lua
+++ b/lua/plugins/editors.lua
@@ -48,6 +48,21 @@ return {
             utils.menu.exec('close')
             utils.bar.exec('update_current_context_hl')
           end,
+          -- open menu like '<CR>'
+          ['l'] = function()
+            local utils = require('dropbar.utils')
+            local menu = utils.menu.get_current()
+            if not menu then
+              return
+            end
+            local cursor = vim.api.nvim_win_get_cursor(menu.win)
+            local component = menu.entries[cursor[1]]:first_clickable(cursor[2])
+            if component then
+              menu:click_on(component, nil, 1, 'l')
+            end
+          end,
+          -- close menu like '<ESC>'
+          ['h'] = '<C-w>q',
         },
         win_configs = {
           border = 'rounded',


### PR DESCRIPTION
FEAT: 在`dropbar.nvim`中, 使用`l`打开下一级菜单; 使用`h`关闭当前菜单。