### PR TITLE
perf: disable lazy.nvim checker

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -23,14 +23,22 @@ require('lazy').setup({
 
     -- enable all languages
     { import = 'plugins.lang' },
-
-    -- { import = "dev" },
   },
-  -- Configure any other settings here. See the documentation for more details.
-  -- colorscheme that will be used when installing plugins.
-  -- install = { colorscheme = { "tokyonight" } },
   -- automatically check for plugin updates
-  checker = { enabled = true },
+  checker = {
+    enabled = false, -- for setup performance, we disable this by default
+    notify = false,
+    -- frequency = 43200, --half day
+  },
+  defaults = {
+    -- By default, only LazyVim plugins will be lazy-loaded. Your custom plugins will load during startup.
+    -- If you know what you're doing, you can set this to `true` to have all your custom plugins lazy-loaded by default.
+    lazy = false,
+    -- It's recommended to leave version=false for now, since a lot the plugin that support versioning,
+    -- have outdated releases, which may break your Neovim install.
+    version = false, -- always use the latest git commit
+    -- version = "*", -- try installing the latest stable version for plugins that support semver
+  },
   performance = {
     rtp = {
       -- disable some rtp plugins


### PR DESCRIPTION
if set `checker: { enabled = true }`, got bad performance when I press `f` for `find files` or `g` for `grep text` in setup dashboard, so I disable it.

如果设置`checker: { enabled = true }`, 在启动页面我按下`f`搜索文件或者按下`g`搜索文本时性能很差, 所以我禁用了它。